### PR TITLE
Improve Makefile robustness and dependency handling

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,9 +3,13 @@ CXX = clang++
 # Note: MAKE is implicitly defined, no need to export unless overriding
 
 # --- Paths to Dependencies ---
+
 EIGEN3_PATH    = __EIGEN3_PATH__
+# Eigen3: The path where you can find "Eigen/", "signature_of_eigen3_matrix_library" and "unsupported/".
 LIBINT2_PATH   = __LIBINT2_PATH__
+# LIBINT2: path where you can find "include/", "lib/" and "share/".
 LIBXC_PATH     = __LIBXC_PATH__
+# LIBXC: path where you can find "bin/", "include/" and "lib/".
 MANIVERSE_PATH = __MANIVERSE_PATH__
 
 # --- Project Structure ---

--- a/makefile
+++ b/makefile
@@ -3,7 +3,6 @@ CXX = clang++
 # Note: MAKE is implicitly defined, no need to export unless overriding
 
 # --- Paths to Dependencies ---
-
 EIGEN3_PATH    = __EIGEN3_PATH__
 # Eigen3: The path where you can find "Eigen/", "signature_of_eigen3_matrix_library" and "unsupported/".
 LIBINT2_PATH   = __LIBINT2_PATH__

--- a/makefile
+++ b/makefile
@@ -1,29 +1,93 @@
-export MAKE = __MAKE__
-export CXX = __CXX__
+# --- Compiler ---
+CXX = clang++
+# Note: MAKE is implicitly defined, no need to export unless overriding
 
-export EIGEN3 = __EIGEN3__
-# The path where you can find "Eigen/", "signature_of_eigen3_matrix_library" and "unsupported/".
-export LIBINT2 = __LIBINT2__
-# The path where you can find "include/", "lib/" and "share/".
-export LIBXC = __LIBXC__
-# The path where you can find "bin/", "include/" and "lib/".
-export MANIVERSE = __MANIVERSE__
+# --- Paths to Dependencies ---
+EIGEN3_PATH    = __EIGEN3_PATH__
+LIBINT2_PATH   = __LIBINT2_PATH__
+LIBXC_PATH     = __LIBXC_PATH__
+MANIVERSE_PATH = __MANIVERSE_PATH__
 
-export GeneralFlags = -Wall -Wextra -Wpedantic -fopenmp -O3 -std=c++2a
-export EIGEN3Flags = -isystem $(EIGEN3) -march=native -DEIGEN_INITIALIZE_MATRICES_BY_ZERO
-export LIBINT2Flags = -isystem $(LIBINT2)/include/ -L$(LIBINT2)/lib/ -lint2
-export LIBXCFlags = -isystem $(LIBXC)/include/ -L$(LIBXC)/lib/ -lxc
-export MANIVERSEFlags = -isystem $(MANIVERSE)/include/ -L$(MANIVERSE)/lib/ -l:libmaniverse.a
+# --- Project Structure ---
+TARGET      = Chinium
+SRCDIR      = src
+OBJDIR      = obj
+SOURCES     = $(shell find $(SRCDIR) -name '*.cpp')
+# Generate corresponding object file paths in OBJDIR, preserving subdirectory structure
+OBJECTS     = $(patsubst $(SRCDIR)/%.cpp,$(OBJDIR)/%.o,$(SOURCES))
+# Generate dependency files (optional but good practice for header changes)
+DEPS        = $(OBJECTS:.o=.d)
 
+# --- Build Flags ---
+# General Compiler Flags (apply to compilation steps)
+# Using -isystem for external libraries suppresses warnings from their headers
+# Added -MMD -MP to generate dependency files (.d)
+CPPFLAGS    = -isystem $(EIGEN3_PATH) \
+              -isystem $(LIBINT2_PATH)/include \
+              -isystem $(LIBXC_PATH)/include \
+              -isystem $(MANIVERSE_PATH)/include \
+              -DEIGEN_INITIALIZE_MATRICES_BY_ZERO \
+              -MMD -MP # Generate dependency files
+
+CXXFLAGS    = -Wall -Wextra -Wpedantic -fopenmp -O3 -std=c++2a -march=native
+
+# Linker Flags (apply to the final linking step)
+# -L flags specify paths for the *linker* to search during the build
+# -Wl,-rpath, flags embed paths into the executable for the *runtime dynamic linker*
+LDFLAGS     = -L$(LIBINT2_PATH)/lib \
+              -L$(LIBXC_PATH)/lib64 \
+              -L$(MANIVERSE_PATH)/lib \
+              -Wl,-rpath,$(LIBINT2_PATH)/lib \
+              -Wl,-rpath,$(LIBXC_PATH)/lib64 \
+              -Wl,-rpath,$(MANIVERSE_PATH)/lib \
+              -fopenmp # Often needed for linking OpenMP code too
+
+# Libraries to Link
+LDLIBS      = -lint2 \
+              -lxc \
+              -l:libmaniverse.a # Explicitly link the static archive
+
+# --- Main Rules ---
+
+# Default target: build the executable
 .PHONY: all
+all: $(TARGET)
 
-all:
-	mkdir -p obj/
-	$(MAKE) -C src/
-	cd obj/ && $(CXX) -o ../Chinium *.o $(GeneralFlags) $(EIGEN3Flags) $(LIBINT2Flags) $(LIBXCFlags) $(MANIVERSEFlags)
+# Rule to link the executable
+$(TARGET): $(OBJECTS)
+	@echo "Linking $@..."
+	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS) $(LDLIBS)
+	# $^ expands to all prerequisites (the object files)
+	# CXXFLAGS are included in the link step (good practice for LTO, -fopenmp etc.)
 
-ld:
-	cd obj/ && $(CXX) -o ../Chinium *.o $(GeneralFlags) $(EIGEN3Flags) $(LIBINT2Flags) $(LIBXCFlags) $(MANIVERSEFlags)
+# --- Compilation Rule ---
 
+# Pattern rule to compile .cpp files from SRCDIR into .o files in OBJDIR
+# This handles source files in subdirectories of SRCDIR as well.
+$(OBJDIR)/%.o: $(SRCDIR)/%.cpp | $(OBJDIR) # Use order-only prerequisite for OBJDIR
+	@echo "Compiling $< -> $@..."
+	@mkdir -p $(@D) # Create subdirectory in obj/ if it doesn't exist
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+
+# $< expands to the first prerequisite (the .cpp file)
+# $@ expands to the target (the .o file)
+# $(@D) expands to the directory part of the target
+
+# --- Utility Rules ---
+
+# Rule to create the object directory
+# This is triggered by the order-only prerequisite in the compilation rule
+$(OBJDIR):
+	@echo "Creating directory $@"
+	@mkdir -p $@
+
+# Rule to clean up generated files
+.PHONY: clean
 clean:
-	rm -rf obj/*.o
+	@echo "Cleaning..."
+	rm -f $(TARGET)   # Remove executable
+	rm -rf $(OBJDIR)  # Remove object directory and all its contents (.o, .d files)
+
+# Include dependency files, if they exist
+# This makes Make automatically recompile files if included headers change
+-include $(DEPS)


### PR DESCRIPTION
This commit significantly refactors the Makefile to address several issues
with the previous recursive approach and improve overall build reliability
and ease of use.

Key changes include:

*   **Eliminate Recursion:** Removed the `make -C src/` call. All compilation
    and linking is now managed directly by the top-level Makefile. This
    allows Make to correctly track dependencies between source and object
    files.
*   **Robust Dependency Tracking:**
    *   Automatically discovers `.cpp` source files within the `src/` tree
      using `find`.
    *   Uses pattern rules (`$(OBJDIR)/%.o: $(SRCDIR)/%.cpp`) to compile
      sources into a corresponding structure within the `obj/` directory.
    *   Implements automatic C/C++ header dependency generation (`-MMD -MP`)
      and inclusion (`-include $(DEPS)`). This ensures files are correctly
      recompiled when included headers change, fixing the issue where Make
      didn't "remember" built files across invocations.
*   **Standardized Flags:** Separated compiler/linker flags into standard
    Make variables (`CPPFLAGS`, `CXXFLAGS`, `LDFLAGS`, `LDLIBS`) for clarity
    and maintainability. Switched to using `-isystem` for external library
    include paths to suppress warnings from those headers.
*   **Embed Runtime Paths (RPATH):** Added `-Wl,-rpath` flags to the `LDFLAGS`.
    This embeds the necessary library paths for `libint2` and `libxc`
    directly into the executable's `DT_RUNPATH` entry. This simplifies
    running the compiled binary without needing to manually set
    `LD_LIBRARY_PATH` or rely on system-wide library configurations.
*   **Cleanup:** Refined the `clean` target to remove the executable and the
    entire object directory (`obj/`). Removed the redundant `ld` target as
    its functionality is covered by the main `all` target.
*   **Clarity:** Improved variable naming (e.g., `*_PATH`) and added comments
    to explain different sections of the Makefile.

These changes result in a more standard, maintainable, and reliable build
process that correctly handles dependencies and simplifies runtime execution
of the final executable.